### PR TITLE
Update backup.sh

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -13,7 +13,7 @@ while /bin/true; do
     if [ -f $VER/new.tar.gz ]; then 
       mv $VER/new.tar.gz $VER/old.tar.gz
     fi
-    mv 2* $VER/new.tar.gz
+    ls *.tar.gz -tr | tail -n 1 | xargs -I{} mv {} $VER/new.tar.gz
     echo "Backup saved to /backup/$VER/new.tar.gz"
   fi
 done


### PR DESCRIPTION
The current move command will fail if there is more than one backup file in the directory.
That can happen if someone starts a backup manually within the Freepbx GUI.
New proposed command will find the latest backup only.